### PR TITLE
Use button variants for answer feedback

### DIFF
--- a/components/spanish-learning-game.tsx
+++ b/components/spanish-learning-game.tsx
@@ -340,13 +340,14 @@ export function SpanishLearningGame() {
                         key={option.text}
                         onClick={() => handleAnswer(option.text)}
                         disabled={showResult}
-                        className={`h-auto flex flex-col items-center p-4 gap-2 font-body ${
+                        variant={
                           showResult && option.text === currentWord.dutch
-                            ? "bg-green-500 text-white"
+                            ? "success"
                             : showResult && option.text === selectedAnswer
-                              ? "bg-red-500 text-white"
-                              : ""
-                        }`}
+                              ? "destructive"
+                              : undefined
+                        }
+                        className="h-auto flex flex-col items-center p-4 gap-2 font-body transition-colors"
                       >
                         <img
                           src={option.image}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -13,6 +13,8 @@ const buttonVariants = cva(
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        success:
+          "bg-green-500 text-white shadow-xs hover:bg-green-500/90 focus-visible:ring-green-500/20 dark:focus-visible:ring-green-500/40 ring-1 ring-green-500/50 transition-colors",
         outline:
           "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
         secondary:


### PR DESCRIPTION
## Summary
- add success variant to shared Button component for green correct states
- replace hard-coded answer colors with Button variants in SpanishLearningGame

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bcb8a75468832e854f801e1cdbef68