### PR TITLE
Add animated welcome screen to Spanish learning game

### DIFF
--- a/components/spanish-learning-game.tsx
+++ b/components/spanish-learning-game.tsx
@@ -7,6 +7,7 @@ import { Loader2, Volume2, VolumeX, Sparkles } from "lucide-react"
 import { DifficultySelector } from "./difficulty-selector"
 import { AchievementSystem } from "./achievement-system"
 import { SoundManager } from "./sound-manager"
+import { WelcomeScreen } from "./welcome-screen"
 import { BrainrotCollection, getRandomCharacterToUnlock, BRAINROT_CHARACTERS } from "./italian-brainrot-characters"
 import { getWordsByDifficulty, SPANISH_WORDS } from "@/lib/words-data"
 
@@ -273,7 +274,13 @@ export function SpanishLearningGame() {
   const perfectGames = gameComplete && totalCorrect === words.length ? 1 : 0
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-4">
+    <div
+      className={
+        gameMode === "welcome"
+          ? "min-h-screen"
+          : "min-h-screen flex items-center justify-center p-4"
+      }
+    >
       <SoundManager
         playCorrect={playCorrectSound && soundEnabled}
         playIncorrect={playIncorrectSound && soundEnabled}
@@ -282,13 +289,10 @@ export function SpanishLearningGame() {
       />
 
       {gameMode === "welcome" && (
-        <Card className="w-full max-w-md text-center">
-          <CardContent className="p-6">
-            <h1 className="text-3xl font-heading mb-4">Spaans Leren Game</h1>
-            <Button className="mr-2" onClick={() => setGameMode("select")}>Start</Button>
-            <Button variant="secondary" onClick={() => setGameMode("collection")}>Collectie</Button>
-          </CardContent>
-        </Card>
+        <WelcomeScreen
+          onStart={() => setGameMode("select")}
+          onCollection={() => setGameMode("collection")}
+        />
       )}
 
       {gameMode === "select" && (

--- a/components/welcome-screen.tsx
+++ b/components/welcome-screen.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import Image from "next/image"
+import { Button } from "@/components/ui/button"
+import { Play, Sparkles } from "lucide-react"
+
+interface WelcomeScreenProps {
+  onStart: () => void
+  onCollection: () => void
+}
+
+export function WelcomeScreen({ onStart, onCollection }: WelcomeScreenProps) {
+  return (
+    <div className="min-h-screen w-full flex flex-col items-center justify-center text-center bg-background p-4">
+      <Image
+        src="/sahur-tung-tung-tung-sahur.gif"
+        alt="Sahur animation"
+        width={400}
+        height={400}
+        priority
+        className="mb-8"
+      />
+      <h1 className="text-4xl md:text-6xl font-heading text-primary mb-4">Spaans Leren Game</h1>
+      <p className="text-lg md:text-2xl font-body text-foreground mb-8 max-w-2xl">
+        Leer en verzamel personages terwijl je Spaans oefent!
+      </p>
+      <div className="flex flex-col sm:flex-row gap-4">
+        <Button size="lg" onClick={onStart}>
+          <Play className="mr-2 h-5 w-5" />
+          Start
+        </Button>
+        <Button size="lg" variant="secondary" onClick={onCollection}>
+          <Sparkles className="mr-2 h-5 w-5" />
+          Collectie
+        </Button>
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- replace welcome card with full-screen hero screen
- add new `WelcomeScreen` component with sahur gif and prominent buttons
- adjust layout to show hero during welcome mode

## Testing
- `pnpm lint` *(fails: prompts for ESLint configuration)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68bcc53efa4c832e8f116c3782f1b5de